### PR TITLE
Implement data processing for Simpsons-MNIST dataset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.ipynb_checkpoints/

--- a/data_processing.ipynb
+++ b/data_processing.ipynb
@@ -1,0 +1,143 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "bf2a3e9d",
+   "metadata": {},
+   "source": [
+    "# Data Processing for Simpsons-MNIST\n",
+    "This notebook loads the Simpsons-MNIST dataset, normalizes images, flattens them, and creates stratified train/validation/test splits."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "37ef54e4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-01T15:03:51.461235Z",
+     "iopub.status.busy": "2025-09-01T15:03:51.460973Z",
+     "iopub.status.idle": "2025-09-01T15:03:51.559428Z",
+     "shell.execute_reply": "2025-09-01T15:03:51.558726Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from typing import Tuple, List\n",
+    "\n",
+    "import numpy as np\n",
+    "from PIL import Image\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "20dcd218",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-01T15:03:51.561960Z",
+     "iopub.status.busy": "2025-09-01T15:03:51.561671Z",
+     "iopub.status.idle": "2025-09-01T15:03:51.571924Z",
+     "shell.execute_reply": "2025-09-01T15:03:51.571110Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def _load_images_from_folder(folder: str, mode: str) -> np.ndarray:\n",
+    "    images: List[np.ndarray] = []\n",
+    "    for file in sorted(os.listdir(folder)):\n",
+    "        if not file.lower().endswith('.jpg'):\n",
+    "            continue\n",
+    "        path = os.path.join(folder, file)\n",
+    "        img = Image.open(path)\n",
+    "        if mode == 'grayscale':\n",
+    "            img = img.convert('L')\n",
+    "        else:\n",
+    "            img = img.convert('RGB')\n",
+    "        arr = np.asarray(img, dtype=np.float32) / 255.0\n",
+    "        images.append(arr.flatten())\n",
+    "    return np.stack(images, axis=0)\n",
+    "\n",
+    "\n",
+    "def load_simpsons_mnist(base_dir: str,\n",
+    "                        mode: str = 'rgb',\n",
+    "                        val_ratio: float = 0.2,\n",
+    "                        seed: int = 42):\n",
+    "    rng = np.random.default_rng(seed)\n",
+    "    train_dir = os.path.join(base_dir, mode, 'train')\n",
+    "    test_dir = os.path.join(base_dir, mode, 'test')\n",
+    "    classes = sorted(d for d in os.listdir(train_dir) if not d.startswith('.'))\n",
+    "    train_data, train_labels, test_data, test_labels = [], [], [], []\n",
+    "    for label, cls in enumerate(classes):\n",
+    "        cls_train = os.path.join(train_dir, cls)\n",
+    "        cls_test = os.path.join(test_dir, cls)\n",
+    "        imgs_train = _load_images_from_folder(cls_train, mode)\n",
+    "        imgs_test = _load_images_from_folder(cls_test, mode)\n",
+    "        train_data.append(imgs_train)\n",
+    "        train_labels.append(np.full(imgs_train.shape[0], label, dtype=np.int32))\n",
+    "        test_data.append(imgs_test)\n",
+    "        test_labels.append(np.full(imgs_test.shape[0], label, dtype=np.int32))\n",
+    "    X = np.vstack(train_data)\n",
+    "    y = np.concatenate(train_labels)\n",
+    "    X_test = np.vstack(test_data)\n",
+    "    y_test = np.concatenate(test_labels)\n",
+    "    train_indices, val_indices = [], []\n",
+    "    for label in np.unique(y):\n",
+    "        idx = np.where(y == label)[0]\n",
+    "        rng.shuffle(idx)\n",
+    "        split = int(len(idx) * (1 - val_ratio))\n",
+    "        train_indices.extend(idx[:split])\n",
+    "        val_indices.extend(idx[split:])\n",
+    "    X_train, y_train = X[train_indices], y[train_indices]\n",
+    "    X_val, y_val = X[val_indices], y[val_indices]\n",
+    "    return (X_train, y_train), (X_val, y_val), (X_test, y_test), classes\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "58b7a8b1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-01T15:03:51.574270Z",
+     "iopub.status.busy": "2025-09-01T15:03:51.574066Z",
+     "iopub.status.idle": "2025-09-01T15:03:53.160708Z",
+     "shell.execute_reply": "2025-09-01T15:03:53.160127Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "((7200, 784), (800, 784), (2000, 784), 10)"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(train_X, train_y), (val_X, val_y), (test_X, test_y), classes = load_simpsons_mnist('simpsons-mnist-0.1-rgb/dataset', mode='grayscale', val_ratio=0.1)\n",
+    "train_X.shape, val_X.shape, test_X.shape, len(classes)"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- replace Python module with executed Jupyter notebook that loads and splits Simpsons-MNIST data
- ignore Jupyter notebook checkpoints in version control

## Testing
- `jupyter nbconvert --to notebook --execute data_processing.ipynb --output data_processing.ipynb`
- `python - <<'PY'
import nbformat
nb = nbformat.read('data_processing.ipynb', as_version=4)
print(nb['cells'][3]['outputs'][0]['data']['text/plain'])
PY`


------
https://chatgpt.com/codex/tasks/task_b_68b5b0dfe46c8321aceb575d334b7434