### PR TITLE
Support loading both RGB and grayscale Simpsons-MNIST data

### DIFF
--- a/data_processing.ipynb
+++ b/data_processing.ipynb
@@ -15,18 +15,16 @@
    "id": "37ef54e4",
    "metadata": {
     "execution": {
-
      "iopub.execute_input": "2025-09-01T16:37:59.724481Z",
      "iopub.status.busy": "2025-09-01T16:37:59.724277Z",
      "iopub.status.idle": "2025-09-01T16:37:59.820148Z",
      "shell.execute_reply": "2025-09-01T16:37:59.819706Z"
-
     }
    },
    "outputs": [],
    "source": [
     "import os\n",
-    "from typing import Tuple, List\n",
+    "from typing import Tuple, List, Dict, Union\n",
     "\n",
     "import numpy as np\n",
     "from PIL import Image\n"
@@ -38,18 +36,18 @@
    "id": "20dcd218",
    "metadata": {
     "execution": {
-
      "iopub.execute_input": "2025-09-01T16:37:59.822852Z",
      "iopub.status.busy": "2025-09-01T16:37:59.822362Z",
      "iopub.status.idle": "2025-09-01T16:37:59.831624Z",
      "shell.execute_reply": "2025-09-01T16:37:59.831260Z"
-
     }
    },
    "outputs": [],
    "source": [
-    "def _load_images_from_folder(folder: str, mode: str) -> np.ndarray:\n",
+    "def _load_images_from_folder(folder: Union[str, Dict[str, str]], mode: str):\n",
     "    images: List[np.ndarray] = []\n",
+    "    if mode == 'both':\n",
+    "        return {m: _load_images_from_folder(p, m) for m, p in folder.items()}\n",
     "    for file in sorted(os.listdir(folder)):\n",
     "        if not file.lower().endswith('.jpg'):\n",
     "            continue\n",
@@ -69,33 +67,70 @@
     "                        val_ratio: float = 0.2,\n",
     "                        seed: int = 42):\n",
     "    rng = np.random.default_rng(seed)\n",
-    "    train_dir = os.path.join(base_dir, mode, 'train')\n",
-    "    test_dir = os.path.join(base_dir, mode, 'test')\n",
-    "    classes = sorted(d for d in os.listdir(train_dir) if not d.startswith('.'))\n",
-    "    train_data, train_labels, test_data, test_labels = [], [], [], []\n",
-    "    for label, cls in enumerate(classes):\n",
-    "        cls_train = os.path.join(train_dir, cls)\n",
-    "        cls_test = os.path.join(test_dir, cls)\n",
-    "        imgs_train = _load_images_from_folder(cls_train, mode)\n",
-    "        imgs_test = _load_images_from_folder(cls_test, mode)\n",
-    "        train_data.append(imgs_train)\n",
-    "        train_labels.append(np.full(imgs_train.shape[0], label, dtype=np.int32))\n",
-    "        test_data.append(imgs_test)\n",
-    "        test_labels.append(np.full(imgs_test.shape[0], label, dtype=np.int32))\n",
-    "    X = np.vstack(train_data)\n",
-    "    y = np.concatenate(train_labels)\n",
-    "    X_test = np.vstack(test_data)\n",
-    "    y_test = np.concatenate(test_labels)\n",
-    "    train_indices, val_indices = [], []\n",
-    "    for label in np.unique(y):\n",
-    "        idx = np.where(y == label)[0]\n",
-    "        rng.shuffle(idx)\n",
-    "        split = int(len(idx) * (1 - val_ratio))\n",
-    "        train_indices.extend(idx[:split])\n",
-    "        val_indices.extend(idx[split:])\n",
-    "    X_train, y_train = X[train_indices], y[train_indices]\n",
-    "    X_val, y_val = X[val_indices], y[val_indices]\n",
-    "    return (X_train, y_train), (X_val, y_val), (X_test, y_test), classes\n"
+    "    if mode == 'both':\n",
+    "        classes = sorted(d for d in os.listdir(os.path.join(base_dir, 'rgb', 'train')) if not d.startswith('.'))\n",
+    "        train_data = {'rgb': [], 'grayscale': []}\n",
+    "        test_data = {'rgb': [], 'grayscale': []}\n",
+    "        train_labels, test_labels = [], []\n",
+    "        for label, cls in enumerate(classes):\n",
+    "            cls_train = {\n",
+    "                'rgb': os.path.join(base_dir, 'rgb', 'train', cls),\n",
+    "                'grayscale': os.path.join(base_dir, 'grayscale', 'train', cls)\n",
+    "            }\n",
+    "            cls_test = {\n",
+    "                'rgb': os.path.join(base_dir, 'rgb', 'test', cls),\n",
+    "                'grayscale': os.path.join(base_dir, 'grayscale', 'test', cls)\n",
+    "            }\n",
+    "            imgs_train = _load_images_from_folder(cls_train, 'both')\n",
+    "            imgs_test = _load_images_from_folder(cls_test, 'both')\n",
+    "            for m in imgs_train:\n",
+    "                train_data[m].append(imgs_train[m])\n",
+    "                test_data[m].append(imgs_test[m])\n",
+    "            train_labels.append(np.full(imgs_train['rgb'].shape[0], label, dtype=np.int32))\n",
+    "            test_labels.append(np.full(imgs_test['rgb'].shape[0], label, dtype=np.int32))\n",
+    "        X = {m: np.vstack(train_data[m]) for m in train_data}\n",
+    "        y = np.concatenate(train_labels)\n",
+    "        X_test = {m: np.vstack(test_data[m]) for m in test_data}\n",
+    "        y_test = np.concatenate(test_labels)\n",
+    "        train_indices, val_indices = [], []\n",
+    "        for label in np.unique(y):\n",
+    "            idx = np.where(y == label)[0]\n",
+    "            rng.shuffle(idx)\n",
+    "            split = int(len(idx) * (1 - val_ratio))\n",
+    "            train_indices.extend(idx[:split])\n",
+    "            val_indices.extend(idx[split:])\n",
+    "        X_train = {m: X[m][train_indices] for m in X}\n",
+    "        X_val = {m: X[m][val_indices] for m in X}\n",
+    "        y_train, y_val = y[train_indices], y[val_indices]\n",
+    "        return (X_train, y_train), (X_val, y_val), (X_test, y_test), classes\n",
+    "    else:\n",
+    "        train_dir = os.path.join(base_dir, mode, 'train')\n",
+    "        test_dir = os.path.join(base_dir, mode, 'test')\n",
+    "        classes = sorted(d for d in os.listdir(train_dir) if not d.startswith('.'))\n",
+    "        train_data, train_labels, test_data, test_labels = [], [], [], []\n",
+    "        for label, cls in enumerate(classes):\n",
+    "            cls_train = os.path.join(train_dir, cls)\n",
+    "            cls_test = os.path.join(test_dir, cls)\n",
+    "            imgs_train = _load_images_from_folder(cls_train, mode)\n",
+    "            imgs_test = _load_images_from_folder(cls_test, mode)\n",
+    "            train_data.append(imgs_train)\n",
+    "            train_labels.append(np.full(imgs_train.shape[0], label, dtype=np.int32))\n",
+    "            test_data.append(imgs_test)\n",
+    "            test_labels.append(np.full(imgs_test.shape[0], label, dtype=np.int32))\n",
+    "        X = np.vstack(train_data)\n",
+    "        y = np.concatenate(train_labels)\n",
+    "        X_test = np.vstack(test_data)\n",
+    "        y_test = np.concatenate(test_labels)\n",
+    "        train_indices, val_indices = [], []\n",
+    "        for label in np.unique(y):\n",
+    "            idx = np.where(y == label)[0]\n",
+    "            rng.shuffle(idx)\n",
+    "            split = int(len(idx) * (1 - val_ratio))\n",
+    "            train_indices.extend(idx[:split])\n",
+    "            val_indices.extend(idx[split:])\n",
+    "        X_train, y_train = X[train_indices], y[train_indices]\n",
+    "        X_val, y_val = X[val_indices], y[val_indices]\n",
+    "        return (X_train, y_train), (X_val, y_val), (X_test, y_test), classes\n"
    ]
   },
   {
@@ -104,17 +139,14 @@
    "id": "58b7a8b1",
    "metadata": {
     "execution": {
-
      "iopub.execute_input": "2025-09-01T16:37:59.833624Z",
      "iopub.status.busy": "2025-09-01T16:37:59.833312Z",
      "iopub.status.idle": "2025-09-01T16:38:01.467147Z",
      "shell.execute_reply": "2025-09-01T16:38:01.466761Z"
-
     }
    },
    "outputs": [
     {
-
      "name": "stdout",
      "output_type": "stream",
      "text": [
@@ -123,17 +155,17 @@
       "Test set shape: (2000, 784)\n",
       "Number of classes: 10\n"
      ]
-
     }
    ],
    "source": [
-    "(train_X, train_y), (val_X, val_y), (test_X, test_y), classes = load_simpsons_mnist('simpsons-mnist-0.1-rgb/dataset', mode='grayscale', val_ratio=0.1)\n",
-
-    "print(f\"Train set shape: {train_X.shape}\")\n",
-    "print(f\"Validation set shape: {val_X.shape}\")\n",
-    "print(f\"Test set shape: {test_X.shape}\")\n",
+    "(train_X, train_y), (val_X, val_y), (test_X, test_y), classes = load_simpsons_mnist('simpsons-mnist-0.1-rgb/dataset', mode='both', val_ratio=0.1)\n",
+    "print(f\"Train RGB shape: {train_X['rgb'].shape}\")\n",
+    "print(f\"Train Grayscale shape: {train_X['grayscale'].shape}\")\n",
+    "print(f\"Validation RGB shape: {val_X['rgb'].shape}\")\n",
+    "print(f\"Validation Grayscale shape: {val_X['grayscale'].shape}\")\n",
+    "print(f\"Test RGB shape: {test_X['rgb'].shape}\")\n",
+    "print(f\"Test Grayscale shape: {test_X['grayscale'].shape}\")\n",
     "print(f\"Number of classes: {len(classes)}\")\n"
-
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- Add `mode='both'` option to load Simpsons-MNIST images in both RGB and grayscale
- Return image arrays keyed by color mode while sharing label arrays
- Demonstrate usage by printing dataset shapes for each color mode

## Testing
- `python - <<'PY' ...` (load_simpsons_mnist demo)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b5cffce81083218c463a920f69750a